### PR TITLE
Add missing dependencies for blastkit

### DIFF
--- a/mrnaseq/installing-blastkit.txt
+++ b/mrnaseq/installing-blastkit.txt
@@ -13,6 +13,8 @@ Installing some prerequisites::
 
    pip install pygr
    pip install whoosh
+   pip install Pillow
+   pip install Jinja2
    pip install git+https://github.com/ctb/pygr-draw.git
    pip install git+https://github.com/ged-lab/screed.git
    apt-get -y install lighttpd


### PR DESCRIPTION
Pillow and Jinja2 are needed for blastkit.
